### PR TITLE
Fix compilation errors in main.c

### DIFF
--- a/advanced_programming_signal_processing/main.c
+++ b/advanced_programming_signal_processing/main.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
+#include <math.h>
 //#include <omp.h>
 
 void templateMatchingGray(Image *src, Image *template, Point *position, double *distance)
@@ -131,13 +132,13 @@ int main(int argc, char **argv)
 	if (argc == 6)
 	{
 		char *p = NULL;
-		if (p = strchr(argv[5], 'c') != NULL)
+		if ((p = strchr(argv[5], 'c')) != NULL)
 			clearResult(output_name_txt);
-		if (p = strchr(argv[5], 'w') != NULL)
+		if ((p = strchr(argv[5], 'w')) != NULL)
 			isWriteImageResult = 1;
-		if (p = strchr(argv[5], 'p') != NULL)
+		if ((p = strchr(argv[5], 'p')) != NULL)
 			isPrintResult = 1;
-		if (p = strchr(argv[5], 'g') != NULL)
+		if ((p = strchr(argv[5], 'g')) != NULL)
 			isGray = 1;
 	}
 


### PR DESCRIPTION
Closes #6

## Summary
- `#include <math.h>` が欠落しており `sqrt()` の暗黙的な関数宣言エラーが発生していた問題を修正
- `strchr()` の戻り値代入で演算子の優先度が誤っており（`=` より `!=` が先に評価される）、`int` が `char *` に代入されていた問題を括弧の追加で修正

## Test plan
- [x] `make` でコンパイルエラーなくビルド成功を確認
- [x] `sh run.sh level1` でテンプレートマッチングが正常動作することを確認
- [x] `sh answer.sh result level1` で結果チェックが正常動作することを確認（CORRECT RATE: 9/10）

🤖 Generated with [Claude Code](https://claude.com/claude-code)